### PR TITLE
Fix regexp group extraction issue in db version management

### DIFF
--- a/database/dbase.go
+++ b/database/dbase.go
@@ -24,8 +24,9 @@ func newDbVersion(version string) (*dbVersion, error) {
 		return nil, fmt.Errorf("version %s does not match the required format", version)
 	}
 	// We don't test the Atoi errors as version matches the regexp
-	var maj, _ = strconv.Atoi(match[0])
-	var min, _ = strconv.Atoi(match[1])
+	// Major/Minor version numbers are stored in groups 1 and 2. Group 0 is the whole matched valued
+	var maj, _ = strconv.Atoi(match[1])
+	var min, _ = strconv.Atoi(match[2])
 	return &dbVersion{
 		major: maj,
 		minor: min,

--- a/database/dbase_test.go
+++ b/database/dbase_test.go
@@ -18,10 +18,10 @@ func TestDbVersion(t *testing.T) {
 	}
 
 	var v1, v2 *dbVersion
-	v1, err = newDbVersion("1.0")
+	v1, err = newDbVersion("1.1")
 	assert.Nil(t, err)
 
-	var matchTests = map[string]bool{"0.9": false, "1.0": true, "1.5": true, "2.0": true}
+	var matchTests = map[string]bool{"0.9": false, "1.0": false, "1.1": true, "1.5": true, "2.0": true}
 	for k, v := range matchTests {
 		v2, err = newDbVersion(k)
 		assert.Equal(t, v, v2.matchesRequired(v1))

--- a/metrics/instrumenting.go
+++ b/metrics/instrumenting.go
@@ -132,8 +132,7 @@ type ctHistogram struct {
 }
 
 func (h *ctHistogram) With(labelValues ...string) Histogram {
-	var histo metrics.Histogram
-	histo = h.Histogram.With(labelValues...)
+	var histo = h.Histogram.With(labelValues...)
 	return &ctHistogram{
 		Histogram: histo,
 	}

--- a/middleware/authentication.go
+++ b/middleware/authentication.go
@@ -28,23 +28,17 @@ func MakeHTTPBasicAuthenticationMW(passwordToMatch string, logger cs.Logger) fun
 				return
 			}
 
-			var matched, _ = regexp.MatchString(`^[Bb]asic *`, authorizationHeader)
-
-			if !matched {
+			var regexpBasicAuth = `^[Bb]asic (.+)$`
+			var r = regexp.MustCompile(regexpBasicAuth)
+			var match = r.FindStringSubmatch(authorizationHeader)
+			if match == nil {
 				logger.Log("Authorization Error", "Missing basic token")
 				httpErrorHandler(context.TODO(), http.StatusForbidden, fmt.Errorf("Missing basic token"), w)
 				return
 			}
 
-			var splitToken = strings.Split(authorizationHeader, "Basic ")
-			if len(splitToken) < 2 {
-				splitToken = strings.Split(authorizationHeader, "basic ")
-			}
-
-			var accessToken = splitToken[1]
-
 			// Decode base 64
-			decodedToken, err := base64.StdEncoding.DecodeString(accessToken)
+			decodedToken, err := base64.StdEncoding.DecodeString(match[1])
 
 			if err != nil {
 				logger.Log("Authorization Error", "Invalid base64 token")


### PR DESCRIPTION
The updated unit test would have detected the issue
+ add enhancement with regexp in authorization token check