### PR TITLE
[CLOUDTRUST-1157] Add user_id in events + allow generic HTTP reponse

### DIFF
--- a/database/events.go
+++ b/database/events.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	cs "github.com/cloudtrust/common-service"
@@ -35,6 +36,16 @@ type EventsDBModule interface {
 
 type eventsDBModule struct {
 	db CloudtrustDB
+}
+
+// CreateAdditionalInfo creates the additional info value
+func CreateAdditionalInfo(values ...string) string {
+	var nfo = make(map[string]string)
+	for i := 0; i+1 < len(values); i += 2 {
+		nfo[values[i]] = values[i+1]
+	}
+	addInfo, _ := json.Marshal(nfo)
+	return string(addInfo)
 }
 
 // NewEventsDBModule returns a Console module.

--- a/database/events_test.go
+++ b/database/events_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	cs "github.com/cloudtrust/common-service"
@@ -9,6 +10,13 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCreateAdditionalInfo(t *testing.T) {
+	var addInfo = CreateAdditionalInfo("a", "b", "c", "d", "z")
+	assert.True(t, strings.Contains(addInfo, `"a":"b"`))
+	assert.True(t, strings.Contains(addInfo, `"c":"d"`))
+	assert.False(t, strings.Contains(addInfo, `"z"`))
+}
 
 func TestEventsDBModule(t *testing.T) {
 	var mockCtrl = gomock.NewController(t)

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -32,16 +32,20 @@ type GenericResponse struct {
 
 // WriteResponse writes a response for a mime content type
 func (r *GenericResponse) WriteResponse(w http.ResponseWriter) {
+	w.WriteHeader(r.StatusCode)
+	for k, v := range r.Headers {
+		w.Header().Set(k, v)
+	}
 	if r.MimeContent != nil {
 		w.Header().Set("Content-Type", r.MimeContent.MimeType)
+		if len(r.MimeContent.Filename) > 0 {
+			// Does not support UTF-8 or spaces in filename
+			w.Header().Set("Content-Disposition", "attachment; filename="+r.MimeContent.Filename)
+		}
 		w.Write(r.MimeContent.Content)
 	} else if r.ExportToJSON != nil {
 		writeJSON(r.ExportToJSON, w)
 	}
-	for k, v := range r.Headers {
-		w.Header().Set(k, v)
-	}
-	w.WriteHeader(r.StatusCode)
 }
 
 func writeJSON(exportToJSON interface{}, w http.ResponseWriter) {

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -24,10 +24,10 @@ type MimeContent struct {
 
 // GenericResponse for HTTP requests
 type GenericResponse struct {
-	StatusCode   int
-	Headers      map[string]string
-	MimeContent  *MimeContent
-	ExportToJSON interface{}
+	StatusCode       int
+	Headers          map[string]string
+	MimeContent      *MimeContent
+	JSONableResponse interface{}
 }
 
 // WriteResponse writes a response for a mime content type
@@ -53,15 +53,15 @@ func (r *GenericResponse) WriteResponse(w http.ResponseWriter) {
 	// Body
 	if r.MimeContent != nil {
 		w.Write(r.MimeContent.Content)
-	} else if r.ExportToJSON != nil {
-		writeJSON(r.ExportToJSON, w)
+	} else if r.JSONableResponse != nil {
+		writeJSON(r.JSONableResponse, w)
 	}
 }
 
-func writeJSON(exportToJSON interface{}, w http.ResponseWriter) {
+func writeJSON(jsonableResponse interface{}, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
-	var json, err = json.MarshalIndent(exportToJSON, "", " ")
+	var json, err = json.MarshalIndent(jsonableResponse, "", " ")
 
 	if err == nil {
 		w.Write(json)

--- a/http/handlers_test.go
+++ b/http/handlers_test.go
@@ -41,10 +41,10 @@ func TestHttpGenericResponse(t *testing.T) {
 	// Test with JSON content
 	r.Handle("/path/to/mime", makeHandler(func(_ context.Context, _ interface{}) (response interface{}, err error) {
 		return GenericResponse{
-			StatusCode:   http.StatusNotFound,
-			Headers:      map[string]string{"Location": "here"},
-			MimeContent:  nil,
-			ExportToJSON: make([]int, 0),
+			StatusCode:       http.StatusNotFound,
+			Headers:          map[string]string{"Location": "here"},
+			MimeContent:      nil,
+			JSONableResponse: make([]int, 0),
 		}, nil
 	}))
 	// Test with MimeContent
@@ -55,10 +55,10 @@ func TestHttpGenericResponse(t *testing.T) {
 			Filename: "filename.jpg",
 		}
 		return GenericResponse{
-			StatusCode:   http.StatusCreated,
-			Headers:      nil,
-			MimeContent:  &mime,
-			ExportToJSON: nil,
+			StatusCode:       http.StatusCreated,
+			Headers:          nil,
+			MimeContent:      &mime,
+			JSONableResponse: nil,
 		}, nil
 	}))
 


### PR DESCRIPTION
Generic response let REST methods be able to choose a status code, set headers, return mime content, ...