### PR TITLE
Cloudtrust 1473 rights endpoint

### DIFF
--- a/http/rights.go
+++ b/http/rights.go
@@ -1,0 +1,15 @@
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cloudtrust/common-service/security"
+)
+
+// MakeRigtsHandler makes a HTTP handler that returns information about the rights of the user.
+func MakeRightsHandler(authorizationManager security.AuthorizationManager) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		EncodeReply(context.TODO(), w, authorizationManager.GetRightsOfCurrentUser(r.Context()))
+	})
+}

--- a/http/rights.go
+++ b/http/rights.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/cloudtrust/common-service/security"
@@ -10,6 +9,6 @@ import (
 // MakeRigtsHandler makes a HTTP handler that returns information about the rights of the user.
 func MakeRightsHandler(authorizationManager security.AuthorizationManager) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		EncodeReply(context.TODO(), w, authorizationManager.GetRightsOfCurrentUser(r.Context()))
+		EncodeReply(r.Context(), w, authorizationManager.GetRightsOfCurrentUser(r.Context()))
 	})
 }

--- a/http/rights_test.go
+++ b/http/rights_test.go
@@ -1,0 +1,54 @@
+package http
+
+//go:generate mockgen -destination=./mock/authorization.go -package=mock -mock_names=AuthorizationManager=AuthorizationManager github.com/cloudtrust/common-service/security AuthorizationManager
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudtrust/common-service/http/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeRightsHandler(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockAuthManager := mock.NewAuthorizationManager(mockCtrl)
+
+	var rights = map[string]map[string]map[string]map[string]struct{}{
+		"toe_administrator": map[string]map[string]map[string]struct{}{
+			"GetUsers": map[string]map[string]struct{}{
+				"master": map[string]struct{}{
+					"*": struct{}{},
+				},
+			},
+		},
+	}
+
+	mockAuthManager.EXPECT().GetRightsOfCurrentUser(gomock.Any()).Return(rights)
+
+	r := mux.NewRouter()
+	r.Handle("/rights", MakeRightsHandler(mockAuthManager))
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/rights")
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(res.Body)
+	body := buf.String()
+
+	var response map[string]map[string]map[string]map[string]struct{}
+	err = json.Unmarshal([]byte(body), &response)
+	assert.Equal(t, response, rights)
+	assert.Nil(t, err)
+}

--- a/security/authorization.go
+++ b/security/authorization.go
@@ -155,6 +155,26 @@ func (am *authorizationManager) CheckAuthorizationOnTargetRealm(ctx context.Cont
 	return ForbiddenError{}
 }
 
+// GetRightsOfCurrentUser returns the matrix rights of the current user
+func (am *authorizationManager) GetRightsOfCurrentUser(ctx context.Context) map[string]map[string]map[string]map[string]struct{} {
+	var currentRealm = ctx.Value(cs.CtContextRealm).(string)
+	var currentGroups = ctx.Value(cs.CtContextGroups).([]string)
+
+	//3 dimensions table to express authorizations (group_of_user, action, target_realm) -> target_group for which the action is allowed
+	// We keep group_of_user as a user may be part of multiple groups
+	var rights = map[string]map[string]map[string]map[string]struct{}{}
+
+	for _, group := range currentGroups {
+		rightsForGroup, exist := am.authorizations[currentRealm][group]
+
+		if exist {
+			rights[group] = rightsForGroup
+		}
+	}
+
+	return rights
+}
+
 // ForbiddenError when an operation is not permitted.
 type ForbiddenError struct{}
 
@@ -163,7 +183,7 @@ func (e ForbiddenError) Error() string {
 }
 
 // Authorizations data structure
-// 4 dimensions table to express authorizations (realm_of_user, role_of_user, action, target_realm) -> target_group for which the action is allowed
+// 4 dimensions table to express authorizations (realm_of_user, group_of_user, action, target_realm) -> target_group for which the action is allowed
 type authorizations map[string]map[string]map[string]map[string]map[string]struct{}
 
 // LoadAuthorizations loads the authorization JSON into the data structure
@@ -209,6 +229,7 @@ type AuthorizationManager interface {
 	CheckAuthorizationOnTargetGroup(ctx context.Context, action, targetRealm, targetGroup string) error
 	CheckAuthorizationOnTargetGroupID(ctx context.Context, action, targetRealm, targetGroupID string) error
 	CheckAuthorizationOnTargetUser(ctx context.Context, action, targetRealm, userID string) error
+	GetRightsOfCurrentUser(ctx context.Context) map[string]map[string]map[string]map[string]struct{}
 }
 
 // Authorizations data structure

--- a/security/authorization.go
+++ b/security/authorization.go
@@ -157,8 +157,18 @@ func (am *authorizationManager) CheckAuthorizationOnTargetRealm(ctx context.Cont
 
 // GetRightsOfCurrentUser returns the matrix rights of the current user
 func (am *authorizationManager) GetRightsOfCurrentUser(ctx context.Context) map[string]map[string]map[string]map[string]struct{} {
-	var currentRealm = ctx.Value(cs.CtContextRealm).(string)
-	var currentGroups = ctx.Value(cs.CtContextGroups).([]string)
+	var currentRealm string
+	var currentGroups = []string{}
+	var currentRealmVal = ctx.Value(cs.CtContextRealm)
+	var currentGroupsVal = ctx.Value(cs.CtContextGroups)
+
+	if currentRealmVal != nil {
+		currentRealm = currentRealmVal.(string)
+	}
+
+	if currentGroupsVal != nil {
+		currentGroups = currentGroupsVal.([]string)
+	}
 
 	//3 dimensions table to express authorizations (group_of_user, action, target_realm) -> target_group for which the action is allowed
 	// We keep group_of_user as a user may be part of multiple groups

--- a/security/authorization_test.go
+++ b/security/authorization_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	cs "github.com/cloudtrust/common-service"
-	"github.com/cloudtrust/common-service/security/mock"
 	"github.com/cloudtrust/common-service/log"
+	"github.com/cloudtrust/common-service/security/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -419,5 +419,75 @@ func TestLoadAuthorizations(t *testing.T) {
 
 		_, ok = authorizations["DEP"]["l1_support_manager"]["GetUsers"]["DEP"]["end_user2"]
 		assert.Equal(t, false, ok)
+	}
+}
+
+func TestGetAuthorization(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+	var mockKeycloakClient = mock.NewKeycloakClient(mockCtrl)
+
+	{
+		var jsonAuthz = `{
+			"master":{
+			  "toe_administrator":{
+				"GetUsers": {
+				  "master": {
+					"*": {}
+				  }
+				},
+				"CreateUser": {
+				  "master": {
+					"integrator_manager": {},
+					"integrator_agent": {},
+					"l2_support_manager": {},
+					"l2_support_agent": {},
+					"l3_support_manager": {},
+					"l3_support_agent": {}
+				  }
+				}
+			  },
+			  "l3_support_agent": {}
+			},
+			"DEP":{
+			  "product_administrator":{
+				"GetUsers": {
+				  "DEP": {
+					"*": {}
+				  }
+				},
+				"CreateUser": {
+				  "DEP": {
+					"l1_support_manager": {}
+				  }
+				}
+			  },
+			  "l1_support_manager": {
+				"GetUsers": {
+				  "DEP": {
+					"l1_support_agent": {},
+					"end_user": {}
+				  }
+				}
+			  }
+			}
+		  }`
+
+		var authorizationManager, err = NewAuthorizationManager(mockKeycloakClient, log.NewNopLogger(), jsonAuthz)
+		assert.Nil(t, err)
+
+		var ctx = context.Background()
+		ctx = context.WithValue(ctx, cs.CtContextRealm, "master")
+		ctx = context.WithValue(ctx, cs.CtContextGroups, []string{"toe_administrator"})
+		ctx = context.WithValue(ctx, cs.CtContextUsername, "toe")
+
+		rights := authorizationManager.GetRightsOfCurrentUser(ctx)
+
+		_, ok := rights["toe_administrator"]["GetUsers"]["master"]["*"]
+		assert.Equal(t, true, ok)
+
+		_, ok = rights["toe_administrator"]["CreateUser"]["master"]
+		assert.Equal(t, true, ok)
+
 	}
 }


### PR DESCRIPTION
A new endpoint to get the rights of a user. It is mainly to avoid to leak informations about our available realms (i.e. list of clients)