### PR TITLE
[CLOUDTRUST-2072] Check that correlationId input is valid

### DIFF
--- a/middleware/correlation.go
+++ b/middleware/correlation.go
@@ -3,11 +3,16 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"regexp"
 
 	cs "github.com/cloudtrust/common-service"
 	gen "github.com/cloudtrust/common-service/idgenerator"
 	"github.com/cloudtrust/common-service/log"
 	"github.com/cloudtrust/common-service/tracing"
+)
+
+const (
+	regExpCorrelationID = `^[\w\d_#@-]{1,70}$`
 )
 
 // MakeHTTPCorrelationIDMW retrieve the correlation ID from the HTTP header 'X-Correlation-ID'.
@@ -17,7 +22,7 @@ func MakeHTTPCorrelationIDMW(idGenerator gen.IDGenerator, tracer tracing.Opentra
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			var correlationID = req.Header.Get("X-Correlation-ID")
 
-			if correlationID == "" {
+			if match, _ := regexp.MatchString(regExpCorrelationID, correlationID); !match {
 				correlationID = idGenerator.NextID()
 			}
 

--- a/middleware/correlation_test.go
+++ b/middleware/correlation_test.go
@@ -39,9 +39,9 @@ func TestHTTPCorrelationIDMW(t *testing.T) {
 			assert.Equal(t, corrID, id)
 		})
 
-		// HTTP request with valid correlation ID
 		var m = MakeHTTPCorrelationIDMW(mockIDGenerator, mockTracer, mockLogger, componentName, componentID)(mockHandler)
 
+		// HTTP request with valid correlation ID
 		var req = httptest.NewRequest("GET", "http://cloudtrust.io/getusers", bytes.NewReader([]byte{}))
 		req.Header.Add("X-Correlation-ID", corrID)
 		var w = httptest.NewRecorder()

--- a/middleware/correlation_test.go
+++ b/middleware/correlation_test.go
@@ -39,11 +39,25 @@ func TestHTTPCorrelationIDMW(t *testing.T) {
 			assert.Equal(t, corrID, id)
 		})
 
+		// HTTP request with valid correlation ID
 		var m = MakeHTTPCorrelationIDMW(mockIDGenerator, mockTracer, mockLogger, componentName, componentID)(mockHandler)
 
-		// HTTP request.
 		var req = httptest.NewRequest("GET", "http://cloudtrust.io/getusers", bytes.NewReader([]byte{}))
 		req.Header.Add("X-Correlation-ID", corrID)
+		var w = httptest.NewRecorder()
+
+		m.ServeHTTP(w, req)
+	}
+
+	// HTTP request with invalid correlation ID
+	{
+		var mockHandler = http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			assert.Fail(t, "should not be executed")
+		})
+		var m = MakeHTTPCorrelationIDMW(mockIDGenerator, mockTracer, mockLogger, componentName, componentID)(mockHandler)
+
+		var req = httptest.NewRequest("GET", "http://cloudtrust.io/getusers", bytes.NewReader([]byte{}))
+		req.Header.Add("X-Correlation-ID", "<$+invalid+$>")
 		var w = httptest.NewRecorder()
 
 		m.ServeHTTP(w, req)

--- a/middleware/correlation_test.go
+++ b/middleware/correlation_test.go
@@ -65,9 +65,10 @@ func TestHTTPCorrelationIDMW(t *testing.T) {
 
 	// Without header 'X-Correlation-ID', so there is a call to IDGenerator.
 	{
+		var mockCorrID = "keycloak_bridge-123456789-12645316163-45641615174715"
 		var mockHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			var id = req.Context().Value(cs.CtContextCorrelationID).(string)
-			assert.Equal(t, "keycloak_bridge-123456789-12645316163-45641615174715", id)
+			assert.Equal(t, mockCorrID, id)
 		})
 		var m = MakeHTTPCorrelationIDMW(mockIDGenerator, mockTracer, mockLogger, componentName, componentID)(mockHandler)
 
@@ -75,7 +76,7 @@ func TestHTTPCorrelationIDMW(t *testing.T) {
 		var req = httptest.NewRequest("GET", "http://cloudtrust.io/getusers", bytes.NewReader([]byte{}))
 		var w = httptest.NewRecorder()
 
-		mockIDGenerator.EXPECT().NextID().Return("keycloak_bridge-123456789-12645316163-45641615174715").Times(1)
+		mockIDGenerator.EXPECT().NextID().Return(mockCorrID).Times(1)
 		m.ServeHTTP(w, req)
 	}
 }

--- a/middleware/correlation_test.go
+++ b/middleware/correlation_test.go
@@ -53,7 +53,7 @@ func TestHTTPCorrelationIDMW(t *testing.T) {
 	{
 		var mockHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			var id = req.Context().Value(cs.CtContextCorrelationID).(string)
-			assert.Equal(t, "keycloak_brdige-123456789-12645316163-45641615174715", id)
+			assert.Equal(t, "keycloak_bridge-123456789-12645316163-45641615174715", id)
 		})
 		var m = MakeHTTPCorrelationIDMW(mockIDGenerator, mockTracer, mockLogger, componentName, componentID)(mockHandler)
 
@@ -61,7 +61,7 @@ func TestHTTPCorrelationIDMW(t *testing.T) {
 		var req = httptest.NewRequest("GET", "http://cloudtrust.io/getusers", bytes.NewReader([]byte{}))
 		var w = httptest.NewRecorder()
 
-		mockIDGenerator.EXPECT().NextID().Return("keycloak_brdige-123456789-12645316163-45641615174715").Times(1)
+		mockIDGenerator.EXPECT().NextID().Return("keycloak_bridge-123456789-12645316163-45641615174715").Times(1)
 		m.ServeHTTP(w, req)
 	}
 }


### PR DESCRIPTION
If correlationId is invalid, we create a new one... (we also could choose to refuse to serve the request)