### PR TITLE
[CLOUDTRUST-2438] Don't return HTTP 500 on error in auth. module

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+// Error constants
 const (
 	MsgErrMissingParam = "missingParameter"
 
@@ -105,5 +106,15 @@ func CreateEndpointNotEnabled(param string) Error {
 	return Error{
 		Status:  http.StatusConflict,
 		Message: fmt.Sprintf("%s.%s.%s", GetEmitter(), MsgErrDisabledEndpoint, param),
+	}
+}
+
+// CommonErrorOrDefault returns actualError if it is an Error from this package, returns defaultError otherwise
+func CommonErrorOrDefault(actualError, defaultError error) error {
+	switch actualError.(type) {
+	case Error:
+		return actualError
+	default:
+		return defaultError
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -108,13 +108,3 @@ func CreateEndpointNotEnabled(param string) Error {
 		Message: fmt.Sprintf("%s.%s.%s", GetEmitter(), MsgErrDisabledEndpoint, param),
 	}
 }
-
-// CommonErrorOrDefault returns actualError if it is an Error from this package, returns defaultError otherwise
-func CommonErrorOrDefault(actualError, defaultError error) error {
-	switch actualError.(type) {
-	case Error:
-		return actualError
-	default:
-		return defaultError
-	}
-}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,6 +1,7 @@
 package errorhandler
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,4 +35,16 @@ func TestEmitter(t *testing.T) {
 	var emitter = "component"
 	SetEmitter(emitter)
 	assert.Equal(t, GetEmitter(), emitter)
+}
+
+func TestCommonErrorOrDefault(t *testing.T) {
+	var defErr = errors.New("default error")
+	t.Run("First param is not an errorhandler.Error", func(t *testing.T) {
+		var err = errors.New("any error")
+		assert.Equal(t, defErr, CommonErrorOrDefault(err, defErr))
+	})
+	t.Run("First param is an errorhandler.Error", func(t *testing.T) {
+		var err = CreateNotFoundError("xxx")
+		assert.Equal(t, err, CommonErrorOrDefault(err, defErr))
+	})
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,7 +1,6 @@
 package errorhandler
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,16 +34,4 @@ func TestEmitter(t *testing.T) {
 	var emitter = "component"
 	SetEmitter(emitter)
 	assert.Equal(t, GetEmitter(), emitter)
-}
-
-func TestCommonErrorOrDefault(t *testing.T) {
-	var defErr = errors.New("default error")
-	t.Run("First param is not an errorhandler.Error", func(t *testing.T) {
-		var err = errors.New("any error")
-		assert.Equal(t, defErr, CommonErrorOrDefault(err, defErr))
-	})
-	t.Run("First param is an errorhandler.Error", func(t *testing.T) {
-		var err = CreateNotFoundError("xxx")
-		assert.Equal(t, err, CommonErrorOrDefault(err, defErr))
-	})
 }

--- a/security/authorization.go
+++ b/security/authorization.go
@@ -7,7 +7,6 @@ import (
 
 	cs "github.com/cloudtrust/common-service"
 	"github.com/cloudtrust/common-service/configuration"
-	errorhandler "github.com/cloudtrust/common-service/errors"
 	"github.com/cloudtrust/common-service/log"
 )
 
@@ -27,7 +26,7 @@ func (am *authorizationManager) CheckAuthorizationOnTargetUser(ctx context.Conte
 	var err error
 	if groupsRep, err = am.keycloakClient.GetGroupNamesOfUser(ctx, accessToken, targetRealm, userID); err != nil {
 		am.logger.Info(ctx, "ForbiddenError", err.Error(), "infos", string(infos))
-		return errorhandler.CommonErrorOrDefault(err, ForbiddenError{})
+		return ForbiddenError{}
 	}
 
 	if groupsRep == nil || len(groupsRep) == 0 {
@@ -65,7 +64,7 @@ func (am *authorizationManager) CheckAuthorizationOnTargetGroupID(ctx context.Co
 	var targetGroup string
 	if targetGroup, err = am.keycloakClient.GetGroupName(ctx, accessToken, targetRealm, targetGroupID); err != nil {
 		am.logger.Info(ctx, "ForbiddenError", err.Error(), "infos", string(infos))
-		return errorhandler.CommonErrorOrDefault(err, ForbiddenError{})
+		return ForbiddenError{}
 	}
 
 	if targetGroup == "" {


### PR DESCRIPTION
Required by: cloudtrust/keycloak-bridge#205