### PR TITLE
[CLOUDTRUST-2432] Allow filtering of authorizations

### DIFF
--- a/configuration/mock_test.go
+++ b/configuration/mock_test.go
@@ -1,3 +1,3 @@
 package configuration
 
-//go:generate mockgen -destination=./mock/cloudtrustdb.go -package=mock -mock_names=CloudtrustDB=CloudtrustDB,SQLRow=SQLRow github.com/cloudtrust/common-service/database/sqltypes CloudtrustDB,SQLRow
+//go:generate mockgen -destination=./mock/cloudtrustdb.go -package=mock -mock_names=CloudtrustDB=CloudtrustDB,SQLRow=SQLRow,SQLRows=SQLRows github.com/cloudtrust/common-service/database/sqltypes CloudtrustDB,SQLRow,SQLRows

--- a/configuration/module_test.go
+++ b/configuration/module_test.go
@@ -81,3 +81,80 @@ func TestGetAdminConfiguration(t *testing.T) {
 		assert.Nil(t, err)
 	})
 }
+
+func TestGetAuthorizations(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	var mockDB = mock.NewCloudtrustDB(mockCtrl)
+	var mockSQLRows = mock.NewSQLRows(mockCtrl)
+	var logger = log.NewNopLogger()
+
+	var notInScopeAction = "ACTION#1"
+	var allowedAction = "ACTION#2"
+	var actions = []string{allowedAction}
+	var ctx = context.TODO()
+
+	var module = NewConfigurationReaderDBModule(mockDB, logger, actions)
+
+	t.Run("Query fails", func(t *testing.T) {
+		var sqlError = errors.New("SQL error")
+		mockDB.EXPECT().Query(gomock.Any()).Return(nil, sqlError)
+
+		var _, err = module.GetAuthorizations(ctx)
+		assert.Equal(t, sqlError, err)
+	})
+
+	// Now, query will always be successful
+	mockDB.EXPECT().Query(gomock.Any()).Return(mockSQLRows, nil).AnyTimes()
+	mockSQLRows.EXPECT().Close().AnyTimes()
+
+	t.Run("scan fails", func(t *testing.T) {
+		var scanError = errors.New("scan error")
+		mockSQLRows.EXPECT().Next().Return(true)
+		mockSQLRows.EXPECT().Scan(gomock.Any()).Return(scanError)
+
+		var _, err = module.GetAuthorizations(ctx)
+		assert.Equal(t, scanError, err)
+	})
+
+	t.Run("Query returns 2 rows", func(t *testing.T) {
+		gomock.InOrder(
+			mockSQLRows.EXPECT().Next().Return(true),
+			mockSQLRows.EXPECT().Scan(gomock.Any()).DoAndReturn(func(realmID, groupName, action *string, targetRealm, targetGroup *sql.NullString) error {
+				*realmID = "realm#1"
+				*groupName = "group#1"
+				*action = notInScopeAction
+				*targetRealm = sql.NullString{Valid: false}
+				*targetGroup = sql.NullString{Valid: false}
+				return nil
+			}),
+			mockSQLRows.EXPECT().Next().Return(true),
+			mockSQLRows.EXPECT().Scan(gomock.Any()).DoAndReturn(func(realmID, groupName, action *string, targetRealm, targetGroup *sql.NullString) error {
+				*realmID = "realm#2"
+				*groupName = "group#2"
+				*action = allowedAction
+				*targetRealm = sql.NullString{Valid: true, String: "targetRealm"}
+				*targetGroup = sql.NullString{Valid: true, String: "targetGroup"}
+				return nil
+			}),
+			mockSQLRows.EXPECT().Next().Return(false),
+		)
+
+		var res, err = module.GetAuthorizations(ctx)
+		assert.Nil(t, err)
+		assert.Len(t, res, 1)
+		assert.Equal(t, allowedAction, *res[0].Action)
+	})
+}
+
+func TestIsInScope(t *testing.T) {
+	var module = NewConfigurationReaderDBModule(nil, nil)
+	assert.True(t, module.isInAuthorizationScope("any-auth-will-be-considered-in-scope"))
+
+	module = NewConfigurationReaderDBModule(nil, nil, []string{"autun"}, []string{"auth2", "auth3"})
+	assert.False(t, module.isInAuthorizationScope("any-auth-will-be-considered-in-scope"))
+	assert.True(t, module.isInAuthorizationScope("autun"))
+	assert.True(t, module.isInAuthorizationScope("auth2"))
+	assert.True(t, module.isInAuthorizationScope("auth3"))
+}

--- a/security/authorization.go
+++ b/security/authorization.go
@@ -10,6 +10,16 @@ import (
 	"github.com/cloudtrust/common-service/log"
 )
 
+// AppendActionNames appends name of actions to a name slice
+func AppendActionNames(names []string, actions ...[]Action) []string {
+	for _, actionSet := range actions {
+		for _, action := range actionSet {
+			names = append(names, action.Name)
+		}
+	}
+	return names
+}
+
 func (am *authorizationManager) CheckAuthorizationOnTargetUser(ctx context.Context, action, targetRealm, userID string) error {
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 

--- a/security/authorization_test.go
+++ b/security/authorization_test.go
@@ -17,6 +17,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAppendActionNames(t *testing.T) {
+	assert.Nil(t, AppendActionNames(nil, []Action{}, []Action{}))
+
+	var actions1 = []Action{Action{Name: "1"}}
+	var actions2 = []Action{Action{Name: "2"}, Action{Name: "3"}, Action{Name: "4"}}
+	var actions3 = []Action{Action{Name: "5"}}
+	assert.Equal(t, []string{"1", "2", "3", "4", "5"}, AppendActionNames(nil, actions1, actions2, actions3))
+}
+
 func TestCheckAuthorizationOnRealm(t *testing.T) {
 	var mockCtrl = gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
3 solutions envisagées:
* filtrer sur les préfixes : oblige de boucler sur tous les préfixes pour faire un truc du genre strings.StartsWith(...)
* filtrer avec une map contenant toutes les actions possibles (solution proposée)
* avoir une colonne en DB qui spécifie la source et mettre cette source dans le where... efficace mais nécessite de revoir l'insertion dans la base (colonne qui ne contiendrait que peu de valeurs différentes)