### PR TITLE
[CLOUDTRUST-2805] Get all realm configurations at once

### DIFF
--- a/configuration/module_test.go
+++ b/configuration/module_test.go
@@ -12,6 +12,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetRealmConfigurations(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	var mockDB = mock.NewCloudtrustDB(mockCtrl)
+	var mockSQLRow = mock.NewSQLRow(mockCtrl)
+	var logger = log.NewNopLogger()
+
+	var realmID = "myrealm"
+	var ctx = context.TODO()
+	var module = NewConfigurationReaderDBModule(mockDB, logger)
+
+	t.Run("SQL error", func(t *testing.T) {
+		mockDB.EXPECT().QueryRow(gomock.Any(), realmID).Return(mockSQLRow)
+		mockSQLRow.EXPECT().Scan(gomock.Any(), gomock.Any()).Return(errors.New("SQL error"))
+		var _, _, err = module.GetRealmConfigurations(ctx, realmID)
+		assert.NotNil(t, err)
+	})
+	t.Run("SQL No row", func(t *testing.T) {
+		mockDB.EXPECT().QueryRow(gomock.Any(), realmID).Return(mockSQLRow)
+		mockSQLRow.EXPECT().Scan(gomock.Any(), gomock.Any()).Return(sql.ErrNoRows)
+		var _, _, err = module.GetRealmConfigurations(ctx, realmID)
+		assert.NotNil(t, err)
+	})
+	t.Run("Invalid JSON", func(t *testing.T) {
+		mockDB.EXPECT().QueryRow(gomock.Any(), realmID).Return(mockSQLRow)
+		mockSQLRow.EXPECT().Scan(gomock.Any()).DoAndReturn(func(ptrConfig *string, ptrAdminConfig *string) error {
+			*ptrConfig = `{`
+			*ptrAdminConfig = `{}`
+			return nil
+		})
+		var _, _, err = module.GetRealmConfigurations(ctx, realmID)
+		assert.NotNil(t, err)
+	})
+	t.Run("Success", func(t *testing.T) {
+		mockDB.EXPECT().QueryRow(gomock.Any(), realmID).Return(mockSQLRow)
+		mockSQLRow.EXPECT().Scan(gomock.Any()).DoAndReturn(func(ptrConfig *string, ptrAdminConfig *string) error {
+			*ptrConfig = `{}`
+			*ptrAdminConfig = `{}`
+			return nil
+		})
+		var _, _, err = module.GetRealmConfigurations(ctx, realmID)
+		assert.Nil(t, err)
+	})
+}
+
 func TestGetConfiguration(t *testing.T) {
 	var mockCtrl = gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
When we need both realm configuration and realm admin configuration, we should get them in a single query to avoid db performance issues.