### PR TITLE
[CLOUDTRUST-5180] Log username in basic auth MW

### DIFF
--- a/middleware/authentication.go
+++ b/middleware/authentication.go
@@ -49,6 +49,9 @@ func MakeHTTPBasicAuthenticationFuncMW(credsMatcher func(token string) (*string,
 				httpErrorHandler(ctx, http.StatusUnauthorized, errors.New(errorhandler.MsgErrInvalidParam+"."+errorhandler.Token), w)
 				return
 			}
+
+			logger.Info(ctx, "auth", "User authenticated", "username", *authenticated)
+
 			ctx = context.WithValue(req.Context(), cs.CtContextUsername, *authenticated)
 
 			next.ServeHTTP(w, req.WithContext(ctx))

--- a/middleware/authentication_test.go
+++ b/middleware/authentication_test.go
@@ -136,6 +136,7 @@ func TestHTTPBasicAuthenticationMW(t *testing.T) {
 	req.Header.Set("Authorization", "Basic "+token)
 
 	t.Run("Valid authorization token - Basic", func(t *testing.T) {
+		mockLogger.EXPECT().Info(gomock.Any(), "auth", "User authenticated", "username", "username").Times(1)
 		var result = getAuthenticationResultTest(m, req)
 		assert.Equal(t, http.StatusOK, result.StatusCode)
 	})
@@ -143,6 +144,7 @@ func TestHTTPBasicAuthenticationMW(t *testing.T) {
 	req.Header.Set("Authorization", "basic "+token)
 
 	t.Run("Valid authorization token - basic", func(t *testing.T) {
+		mockLogger.EXPECT().Info(gomock.Any(), "auth", "User authenticated", "username", "username").Times(1)
 		var result = getAuthenticationResultTest(m, req)
 		assert.Equal(t, http.StatusOK, result.StatusCode)
 	})


### PR DESCRIPTION
Logs the username in the HTTP handler of Basic authentication middleware, which is called in the Callback API of the IDNow service (https://bitbucket.svc.elca.ch/projects/CLOUDTRUST/repos/back-idnow-service/browse/cmd/idnowd/idnow_service.go#977).